### PR TITLE
Rpc masking

### DIFF
--- a/elixir/lib/sarkar/action_handlers/platform.ex
+++ b/elixir/lib/sarkar/action_handlers/platform.ex
@@ -28,6 +28,16 @@ defmodule EdMarkaz.ActionHandler.Platform do
 		end
 	end
 
+	def handle_action(%{"type" => "RESERVE_NUMBER", "payload" => %{"school_id" => school_id, "user" => user}, "last_snapshot" => last_sync_date}, %{id: id, client_id: client_id} = state) do
+
+		res = EdMarkaz.Supplier.reserve_masked_number(id, school_id, user, client_id, last_sync_date)
+
+		case res do
+			{:ok, content} -> {:reply, succeed(content), state}
+			{:error, message} -> {:reply, fail(message)}
+		end
+	end
+
 	def handle_action(%{"type" => "SYNC", "payload" => payload, "last_snapshot" => last_sync_date}, %{id: id, client_id: client_id} = state) do
 		res = EdMarkaz.Supplier.sync_changes(id, client_id, payload, last_sync_date)
 

--- a/elixir/lib/sarkar/action_handlers/platform.ex
+++ b/elixir/lib/sarkar/action_handlers/platform.ex
@@ -38,6 +38,16 @@ defmodule EdMarkaz.ActionHandler.Platform do
 		end
 	end
 
+	def handle_action(%{"type" => "RELEASE_NUMBER", "payload" => %{"school_id" => school_id, "user" => user}, "last_snapshot" => last_sync_date}, %{id: id, client_id: client_id} = state) do
+
+		res = EdMarkaz.Supplier.release_masked_number(id, school_id, user, client_id, last_sync_date)
+
+		case res do
+			{:ok, content} -> {:reply, succeed(content), state}
+			{:error, message} -> {:reply, fail(message)}
+		end
+	end
+
 	def handle_action(%{"type" => "SYNC", "payload" => payload, "last_snapshot" => last_sync_date}, %{id: id, client_id: client_id} = state) do
 		res = EdMarkaz.Supplier.sync_changes(id, client_id, payload, last_sync_date)
 

--- a/elixir/lib/sarkar/server/analytics.ex
+++ b/elixir/lib/sarkar/server/analytics.ex
@@ -1,5 +1,5 @@
 defmodule EdMarkaz.Server.Analytics do
-	
+
 	def init(%{bindings: %{type: "hi"}} = req, state) do
 		IO.puts "wowwww"
 		req = :cowboy_req.reply(200, req)

--- a/elixir/lib/sarkar/supplier/supplier.ex
+++ b/elixir/lib/sarkar/supplier/supplier.ex
@@ -35,6 +35,89 @@ defmodule EdMarkaz.Supplier do
 		GenServer.call(via(id), {:reload})
 	end
 
+	def reserve_masked_number(id, school_id, %{"number" => number, "name" => name} = user, client_id, last_sync_date) do
+		sync_state = EdMarkaz.Supplier.get_sync_state(id)
+
+		# should first check if this school is already assigned a number
+
+		available_numbers = Dynamic.get(sync_state, ["mask_pairs"])
+			|> Enum.filter(fn {number, %{ "status" => status }} -> status == "FREE" end)
+			|> Enum.map(fn {number, _} -> number end)
+		
+		time = :os.system_time(:millisecond)
+
+		case available_numbers do
+			[] -> {:error, "No numbers available"}
+			_ -> 
+				num = Enum.random(available_numbers)
+				writes = [
+					%{
+						type: "MERGE",
+						path: ["sync_state", "mask_pairs", num],
+						value: %{
+							"status" => "USED",
+							"school_id" => school_id
+						},
+						date: time,
+						client_id: client_id
+					},
+					%{
+						type: "MERGE",
+						path: ["sync_state", "matches", school_id, "masked_number"],
+						value: num,
+						date: time,
+						client_id: client_id
+					},
+					%{
+						type: "MERGE",
+						path: ["sync_state", "matches", school_id, "status"],
+						value: "IN_PROGRESS",
+						date: time,
+						client_id: client_id
+					},
+					%{
+						type: "MERGE",
+						path: ["sync_state", "matches", school_id, "history", "#{time}"],
+						value: %{
+							"event" => "REVEAL_NUMBER",
+							"time" => time,
+							"user" => user,
+						},
+						date: time,
+						client_id: client_id
+					}
+				]
+
+				changes = prepare_changes(writes)
+
+				%{new_writes: new_writes} = GenServer.call(via(id), {:sync_changes, client_id, changes, last_sync_date})
+
+				IO.inspect new_writes
+
+
+				{:ok, rpc_succeed(writes)}
+		end
+	end
+
+	def prepare_changes(changes) do
+
+		# takes an array of changes which are %{ type: "MERGE" | "DELETE", path: [], value: any} and generates the map needed for sync_changes
+
+		changes 
+		|> Enum.map(fn %{type: type, path: path, value: value} -> {
+			Enum.join(path, ","), %{
+				"action" => %{
+					"path" => path,
+					"type" => type,
+					"value" => value
+				},
+				"date" => :os.system_time(:millisecond)
+			}
+		} end)
+		|> Enum.into(%{})
+
+	end
+
 	def get_last_caller(id, school_id) do
 		sync_state = EdMarkaz.Supplier.get_sync_state(id)
 
@@ -138,8 +221,6 @@ defmodule EdMarkaz.Supplier do
 		end
 
 		# end weird section
-
-		# TODO: sort changes by time and process in order.
 
 		{nextSyncState, nextWrites, new_writes, last_date} = changes
 		|> Enum.sort(fn({ _, %{"date" => d1}}, {_, %{"date" => d2}}) -> d1 < d2 end)
@@ -304,6 +385,13 @@ defmodule EdMarkaz.Supplier do
 			type: "CONFIRM_SYNC_DIFF",
 			date: date,
 			new_writes: new_writes # client should only have to check these against queued / pending writes.
+		}
+	end
+
+	defp rpc_succeed(new_writes) do
+		%{
+			type: "RPC_SUCCEED",
+			new_writes: new_writes
 		}
 	end
 

--- a/elixir/lib/sarkar/supplier/supplier.ex
+++ b/elixir/lib/sarkar/supplier/supplier.ex
@@ -92,9 +92,6 @@ defmodule EdMarkaz.Supplier do
 
 				%{new_writes: new_writes} = GenServer.call(via(id), {:sync_changes, client_id, changes, last_sync_date})
 
-				IO.inspect new_writes
-
-
 				{:ok, rpc_succeed(writes)}
 		end
 	end
@@ -145,8 +142,6 @@ defmodule EdMarkaz.Supplier do
 		changes = prepare_changes(writes)
 
 		%{new_writes: new_writes} = GenServer.call(via(id), {:sync_changes, client_id, changes, last_sync_date})
-
-		IO.inspect new_writes
 
 		{:ok, rpc_succeed(writes)}
 

--- a/web/src/actions/core.ts
+++ b/web/src/actions/core.ts
@@ -168,11 +168,17 @@ export const createDeletes = (paths : Delete[]) => (dispatch : Dispatch<AnyActio
 
 // this is only produced by the server. 
 // it will tell us it hsa confirmed sync up to { date: timestamp }
+export const RPC_SUCCEED = "RPC_SUCCEED"
+export interface RPCSucceedAction {
+	type: "RPC_SUCCEED"
+	new_writes: Write[]
+}
+
 export const CONFIRM_SYNC = "CONFIRM_SYNC"
 export const CONFIRM_SYNC_DIFF = "CONFIRM_SYNC_DIFF"
 export interface ConfirmSyncAction {
-	type: "CONFIRM_SYNC_DIFF",
-	date: number,
+	type: "CONFIRM_SYNC_DIFF"
+	date: number
 	new_writes: Write[]
 }
 

--- a/web/src/actions/index.ts
+++ b/web/src/actions/index.ts
@@ -93,55 +93,6 @@ export const addToSchoolDB = (school: PMIUSchool) => {
 
 export const reserveMaskedNumber = (school_id: string) => (dispatch: Dispatch, getState: GetState, syncr: Syncr) => {
 	// from the pool in state.mask_pairs select an unused number
-	/*
-
-	this is all handled server-side now
-
-	const state = getState();
-
-	const free = Object.entries(state.sync_state.mask_pairs)
-		.filter(([number, v]) => v.status == "FREE")
-		.map(([num,]) => num)
-
-	if (free.length === 0) {
-		alert("The Maximum amount of schools are in progress. To continue, you must mark an existing school as done.")
-		return;
-	}
-
-	const masked_num = free[Math.floor(Math.random() * free.length)]
-
-	const time = new Date().getTime();
-	const event: SupplierInteractionEvent = {
-		event: "REVEAL_NUMBER",
-		time,
-		user: {
-			number: state.auth.number,
-			name: state.sync_state.numbers[state.auth.number].name
-		}
-	}
-
-	dispatch(createMerges([
-		{
-			path: ["sync_state", "mask_pairs", masked_num],
-			value: {
-				status: "USED",
-				school_id
-			}
-		},
-		{
-			path: ["sync_state", "matches", school_id, "masked_number"],
-			value: masked_num
-		},
-		{
-			path: ["sync_state", "matches", school_id, "status"],
-			value: "IN_PROGRESS"
-		},
-		{
-			path: ["sync_state", "matches", school_id, "history", `${time}`],
-			value: event
-		}
-	]))
-	*/
 	const state = getState();
 
 	syncr.send({
@@ -193,42 +144,6 @@ export const releaseMaskedNumber = (school_id: string) => (dispatch: Dispatch, g
 	.catch(err => {
 		console.error(err)
 	})
-
-	/*
-	const masked_num = getState().sync_state.matches[school_id].masked_number
-	const time = new Date().getTime()
-	const state = getState();
-
-	const event: SupplierInteractionEvent = {
-		event: "MARK_DONE",
-		time,
-		user: {
-			number: state.auth.number,
-			name: state.sync_state.numbers[state.auth.number].name
-		}
-	}
-
-	dispatch(createMerges([
-		{
-			path: ["sync_state", "mask_pairs", masked_num],
-			value: {
-				status: "FREE"
-			}
-		},
-		{
-			path: ["sync_state", "matches", school_id, "status"],
-			value: "DONE"
-		},
-		{
-			path: ["sync_state", "matches", school_id, "masked_number"],
-			value: ""
-		},
-		{
-			path: ["sync_state", "matches", school_id, "history", `${time}`],
-			value: event
-		}
-	]))
-	*/
 }
 
 export const saveSchoolRejectedSurvey = (school_id: string, survey: NotInterestedSurvey['meta']) => (dispatch: Dispatch, getState: GetState) => {

--- a/web/src/actions/index.ts
+++ b/web/src/actions/index.ts
@@ -91,8 +91,12 @@ export const addToSchoolDB = (school: PMIUSchool) => {
 	}
 }
 
-export const reserveMaskedNumber = (school_id: string) => (dispatch: Dispatch, getState: GetState) => {
+export const reserveMaskedNumber = (school_id: string) => (dispatch: Dispatch, getState: GetState, syncr: Syncr) => {
 	// from the pool in state.mask_pairs select an unused number
+	/*
+
+	this is all handled server-side now
+
 	const state = getState();
 
 	const free = Object.entries(state.sync_state.mask_pairs)
@@ -137,6 +141,30 @@ export const reserveMaskedNumber = (school_id: string) => (dispatch: Dispatch, g
 			value: event
 		}
 	]))
+	*/
+	const state = getState();
+
+	syncr.send({
+		type: "RESERVE_NUMBER",
+		payload: {
+			school_id,
+			user: {
+				number: state.auth.number,
+				name: state.sync_state.numbers[state.auth.number].name
+			}
+		},
+		client_type: state.auth.client_type,
+		client_id: state.client_id,
+		id: state.auth.id,
+		last_snapshot: state.last_snapshot
+	})
+	.then(res => {
+		console.log(res)
+		dispatch(res)
+	})
+	.catch(err => {
+		console.error(err)
+	})
 
 }
 

--- a/web/src/actions/index.ts
+++ b/web/src/actions/index.ts
@@ -168,8 +168,33 @@ export const reserveMaskedNumber = (school_id: string) => (dispatch: Dispatch, g
 
 }
 
-export const releaseMaskedNumber = (school_id: string) => (dispatch: Dispatch, getState: GetState) => {
+export const releaseMaskedNumber = (school_id: string) => (dispatch: Dispatch, getState: GetState, syncr: Syncr) => {
 
+	const state = getState();
+
+	syncr.send({
+		type: "RELEASE_NUMBER",
+		payload: {
+			school_id,
+			user: {
+				number: state.auth.number,
+				name: state.sync_state.numbers[state.auth.number].name
+			}
+		},
+		client_type: state.auth.client_type,
+		client_id: state.client_id,
+		id: state.auth.id,
+		last_snapshot: state.last_snapshot
+	})
+	.then(res => {
+		console.log(res);
+		dispatch(res)
+	})
+	.catch(err => {
+		console.error(err)
+	})
+
+	/*
 	const masked_num = getState().sync_state.matches[school_id].masked_number
 	const time = new Date().getTime()
 	const state = getState();
@@ -203,6 +228,7 @@ export const releaseMaskedNumber = (school_id: string) => (dispatch: Dispatch, g
 			value: event
 		}
 	]))
+	*/
 }
 
 export const saveSchoolRejectedSurvey = (school_id: string, survey: NotInterestedSurvey['meta']) => (dispatch: Dispatch, getState: GetState) => {

--- a/web/src/components/SchoolInfo/index.tsx
+++ b/web/src/components/SchoolInfo/index.tsx
@@ -32,6 +32,7 @@ interface StateProps {
 
 interface StateType {
 	showSurvey: false | "NOT_INTERESTED" | "CALL_END" | "MARK_COMPLETE"
+	loading: boolean
 }
 
 interface DispatchProps {
@@ -58,6 +59,7 @@ class SchoolInfo extends React.Component<propTypes, StateType> {
 
 		this.state = {
 			showSurvey: false,
+			loading: false
 		}
 
 		this.former = new Former(this, [])
@@ -82,10 +84,22 @@ class SchoolInfo extends React.Component<propTypes, StateType> {
 				showSurvey: "CALL_END"
 			})
 		}
+
+		const currently_masked = Boolean(this.props.schoolMatch && this.props.schoolMatch.masked_number)
+		const next_masked = Boolean(nextProps.schoolMatch && nextProps.schoolMatch.masked_number)
+
+		if(this.state.loading && currently_masked != next_masked) {
+			this.setState({
+				loading: false
+			})
+		}
 	}
 
 	onShowNumber = () => {
 		this.props.reserveNumber()
+		this.setState({
+			loading: true
+		})
 	}
 
 	onMarkComplete = () => {
@@ -96,7 +110,8 @@ class SchoolInfo extends React.Component<propTypes, StateType> {
 		if(res) {
 			this.props.releaseNumber()
 			this.setState({
-				showSurvey: "MARK_COMPLETE"
+				showSurvey: "MARK_COMPLETE",
+				loading: true
 			})
 		}
 	}
@@ -196,13 +211,14 @@ class SchoolInfo extends React.Component<propTypes, StateType> {
 				}
 
 				{ !this.props.connected && <div style={{textAlign: "center", fontSize: "1.2rem" }}>Connecting....</div> }
+				{ this.state.loading && <div style={{textAlign: "center", fontSize: "1.2rem" }}>Retreiving...</div> }
 
-				{ this.props.connected && !reserved && <div className="save-delete">
+				{ this.props.connected && !this.state.loading && !reserved && <div className="save-delete">
 					<div className="red button" onClick={this.onMarkRejected}>Not Interested</div> 
 					<div className="button blue" onClick={this.onShowNumber}>Show Number</div>
 				</div>
 				}
-				{ this.props.connected && reserved && <div className="button purple" onClick={this.onMarkComplete}>Mark as Complete</div> }
+				{ this.props.connected && reserved && !this.state.loading && <div className="button purple" onClick={this.onMarkComplete}>Mark as Complete</div> }
 
 				<div className="row">
 					<label>Status</label>

--- a/web/src/reducers/index.ts
+++ b/web/src/reducers/index.ts
@@ -1,6 +1,6 @@
 import Dynamic from '@ironbay/dynamic'
 
-import { MERGES, MergeAction, DELETES, DeletesAction, CONFIRM_SYNC, CONFIRM_SYNC_DIFF, QUEUE, QueueAction, SNAPSHOT, ON_CONNECT, ON_DISCONNECT, LOGIN_FAIL, LOGIN_SUCCEED, SNAPSHOT_DIFF, LoginSucceed, ConfirmSyncAction, SnapshotDiffAction } from '~/src/actions/core'
+import { MERGES, MergeAction, DELETES, DeletesAction, CONFIRM_SYNC, CONFIRM_SYNC_DIFF, QUEUE, QueueAction, SNAPSHOT, ON_CONNECT, ON_DISCONNECT, LOGIN_FAIL, LOGIN_SUCCEED, SNAPSHOT_DIFF, LoginSucceed, ConfirmSyncAction, SnapshotDiffAction, RPC_SUCCEED, RPCSucceedAction } from '~/src/actions/core'
 import {Actions, ADD_SCHOOL, addSchoolAction, ADD_SCHOOLS, addNewSchoolAction, EditLoginNumberAction, EDIT_LOGIN_NUMBER } from '~/src/actions'
 
 
@@ -142,6 +142,29 @@ const rootReducer = (state : RootBankState, action: Actions) : RootBankState => 
 				queued: newQ,
 				accept_snapshot: true,
 				last_snapshot: new Date().getTime()
+			}
+		}
+
+		case RPC_SUCCEED: 
+		{
+			//@ts-ignore
+			const rpc_action = action as RPCSucceedAction
+
+			if(rpc_action.new_writes.length == 0) {
+				return state
+			}
+
+			const nextState = rpc_action.new_writes.reduce((agg, curr) => {
+
+				if(curr.type == "DELETE") {
+					return Dynamic.delete(agg, curr.path)
+				}
+				return Dynamic.put(agg, curr.path, curr.value)
+
+			}, JSON.parse(JSON.stringify(state))) as RootBankState
+
+			return {
+				...nextState
 			}
 		}
 


### PR DESCRIPTION
A way to make RPC calls without having to modify your reducer and root state. 

You create an action which for now uses `syncr.send` to transmit actions to the backend. Backend then processes in action_handler and GenServer api. It then just calls `:sync_changes` like other changes would, which handles pushing the changes to other clients. The writes are then returned to the client and are handled by a new reducer function which executes them.

The component is then responsible for deciding its "loading/not loading" logic based on the expected difference between current props and nextProps. 

Here it is first implemented for coordinating the number masking assignments on the platform.