### PR TITLE
Increase performance and timeout (ms)

### DIFF
--- a/elixir/lib/sarkar/application.ex
+++ b/elixir/lib/sarkar/application.ex
@@ -30,7 +30,7 @@ defmodule EdMarkaz.Application do
 					types: EdMarkaz.PostgrexTypes,
 					pool: DBConnection.Poolboy,
 					pool_size: 10,
-					timeout: 60000
+					timeout: 60_000 * 20
 			},
 			:poolboy.child_spec(:image_worker, [
 				{:name, {:local, :image_worker}},

--- a/elixir/lib/sarkar/store/school.ex
+++ b/elixir/lib/sarkar/store/school.ex
@@ -13,7 +13,7 @@ defmodule Sarkar.Store.School do
 			|> Enum.map(fn %{"date" => date, "value" => value, "path" => path, "type" => type, "client_id" => client_id} ->
 				[school_id, path, value, date, type, client_id]
 			end)
-			|> Enum.reduce([], fn curr, agg -> Enum.concat(agg, curr) end)
+			|> Enum.reduce([], fn curr, agg -> Enum.concat(curr, agg) end)
 
 		gen_value_strings_writes = Stream.with_index(Map.values(writes), 1)
 			|> Enum.map(fn {w, i} ->
@@ -42,7 +42,7 @@ defmodule Sarkar.Store.School do
 					flat_write = Dynamic.flatten(value)
 						|> Enum.map(fn {p, v} -> {Enum.join(path ++ p, ","), [type, school_id, path ++ p, v, date]} end)
 
-					Enum.concat(agg, flat_write)
+					Enum.concat(flat_write, agg)
 				else
 					[{Enum.join(path, ","), [type, school_id, path, value, date]} | agg]
 					# Enum.concat( agg, [[type, school_id, path, value, date]] )

--- a/elixir/lib/sarkar/store/wrapper.ex
+++ b/elixir/lib/sarkar/store/wrapper.ex
@@ -1,5 +1,5 @@
 defmodule EdMarkaz.DB.Postgres do
 	def query(db, querystring, params, opts \\ []) do
-		Postgrex.query(db, querystring, params, pool: DBConnection.Poolboy, timeout: 60000)
+		Postgrex.query(db, querystring, params, pool: DBConnection.Poolboy, timeout: 60_000 * 20)
 	end
 end


### PR DESCRIPTION
This PR is to:
- increase performance for storing data into `flattened_schools`
- increase timeout for DBConnection ( to ensure, school like GHSAVSchool, loaded successfully)

Note: Increase timeout from `60_000` to `60_000 * 20` is based on assumption of local server with production database for `GHSAVSchool`. We need to merge it by tomorrow.